### PR TITLE
fix function calls to php constructs

### DIFF
--- a/src/JsPhpize/Compiler/Compiler.php
+++ b/src/JsPhpize/Compiler/Compiler.php
@@ -209,7 +209,7 @@ class Compiler
                 return $staticCall;
             }
 
-            return 'function_exists(' . var_export($name, true) . ') ? ' .
+            return 'function_exists(' . var_export($name, true) . ') || in_array(' . var_export($name, true) . ', array(\'isset\', \'array\', \'empty\', \'eval\', \'list\', \'unset\'))? ' .
                 $staticCall . ' : ' .
                 $dynamicCall;
         }


### PR DESCRIPTION
allow `isset()`, `array()`, `empty()`, `eval()`, `list()`, `unset()`