### PR TITLE
Testing if dotHelper matches php behaviour

### DIFF
--- a/tests/dotHelper.php
+++ b/tests/dotHelper.php
@@ -149,18 +149,25 @@ class DotHelperTest extends \PHPUnit_Framework_TestCase
                 ),
             ), 'foo', 'bar', 'biz'));
     }
-
+    /**
+    * @expectedException PHPUnit_Framework_Error_Notice
+    */
+    public function testUndefinedProperties()
+    {
+      $dotHelper = $this->getDotHelper();
+      $object = new MagicCallMethodObject();
+      $dotHelper($object, 'foo');
+    }
     public function testMagicMethod()
     {
         $dotHelper = $this->getDotHelper();
         $object = new MagicMethodObject();
         $partialObject = new SemiMagicMethodObject();
-        $callerObject = new MagicCallMethodObject();
 
         $this->assertSame($object->foo, $dotHelper($object, 'foo'));
-        $this->assertSame($object->nonexistent, $dotHelper($object, 'nonexistent')); #null with above class
-        $this->expectException($dotHelper($callerObject, 'foo'));
-        $this->assertSame($partialObject->bar, $dotHelper($partialObject, 'bar')); #biz
+        // should return `null` given the class's `__get` returns nothing
+        $this->assertSame($object->nonexistent, $dotHelper($object, 'nonexistent'));
+        $this->assertSame($partialObject->bar, $dotHelper($partialObject, 'bar')); //biz
         $this->assertSame('biz', call_user_func($dotHelper($object, 'bar')));
         $this->assertSame(null, call_user_func($dotHelper($object, 'biz')));
     }

--- a/tests/dotHelper.php
+++ b/tests/dotHelper.php
@@ -155,7 +155,7 @@ class DotHelperTest extends \PHPUnit_Framework_TestCase
         $dotHelper = $this->getDotHelper();
         $object = new MagicMethodObject();
         $partialObject = new SemiMagicMethodObject();
-        $callerObject = new MagicCallerMethodObject();
+        $callerObject = new MagicCallMethodObject();
 
         $this->assertSame($object->foo, $dotHelper($object, 'foo'));
         $this->assertSame($object->nonexistent, $dotHelper($object, 'nonexistent')); #null with above class

--- a/tests/dotHelper.php
+++ b/tests/dotHelper.php
@@ -24,6 +24,24 @@ class MagicMethodObject
     }
 }
 
+class MagicCallMethodObject
+{
+    public function __call($name, array $args)
+    {
+        if ($name === 'bar') {
+            return 'biz';
+        }
+    }
+}
+class SemiMagicMethodObject
+{
+    public function __get($name)
+    {
+        if ($name === 'bar') {
+            return 'biz';
+        }
+    }
+}
 class ArrayAccessObject implements \ArrayAccess
 {
     protected $data = array(
@@ -136,8 +154,13 @@ class DotHelperTest extends \PHPUnit_Framework_TestCase
     {
         $dotHelper = $this->getDotHelper();
         $object = new MagicMethodObject();
+        $partialObject = new SemiMagicMethodObject();
+        $callerObject = new MagicCallerMethodObject();
 
-        $this->assertSame('bar', $dotHelper($object, 'foo'));
+        $this->assertSame($object->foo, $dotHelper($object, 'foo'));
+        $this->assertSame($object->nonexistent, $dotHelper($object, 'nonexistent')); #null with above class
+        $this->expectException($dotHelper($callerObject, 'foo'));
+        $this->assertSame($partialObject->bar, $dotHelper($partialObject, 'bar')); #biz
         $this->assertSame('biz', call_user_func($dotHelper($object, 'bar')));
         $this->assertSame(null, call_user_func($dotHelper($object, 'biz')));
     }

--- a/tests/dotHelper.php
+++ b/tests/dotHelper.php
@@ -149,15 +149,17 @@ class DotHelperTest extends \PHPUnit_Framework_TestCase
                 ),
             ), 'foo', 'bar', 'biz'));
     }
+
     /**
-    * @expectedException PHPUnit_Framework_Error_Notice
-    */
+     * @expectedException PHPUnit_Framework_Error_Notice
+     */
     public function testUndefinedProperties()
     {
-      $dotHelper = $this->getDotHelper();
-      $object = new MagicCallMethodObject();
-      $dotHelper($object, 'foo');
+        $dotHelper = $this->getDotHelper();
+        $object = new MagicCallMethodObject();
+        $dotHelper($object, 'foo');
     }
+
     public function testMagicMethod()
     {
         $dotHelper = $this->getDotHelper();


### PR DESCRIPTION
Issues discovered:

1.  When the object doesn't have a `__isset` method and does have a `__get` method, the dot helper returns `null` instead of the value that a native `$foo->bar` would return.
2.  If it does have both `__get` and `__isset`, and also has `_call`, `foo.nonExistentProperty` returns `array($foo, 'nonExistentProperty')` instead of `null`.
3. If it only has `_call`, `foo.nonExistentProperty` returns `array($foo, 'nonExistentProperty')` instead of throwing an error.