### PR TITLE
Version 2

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,5 +3,4 @@ enabled:
 
 disabled:
   - align_double_arrow
-  - short_array_syntax
   - concat_without_spaces

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dist: trusty
 sudo: required
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,12 @@ dist: trusty
 sudo: required
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - hhvm
-
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
+    "php": ">=7.0",
     "ext-mbstring": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.5.0",
     "ext-mbstring": "*"
   },
   "require-dev": {

--- a/examples/indent.php
+++ b/examples/indent.php
@@ -1,7 +1,7 @@
 for ($i = 9; $i; $i--) {
-  if (call_user_func((function ($tiny) {
+  if ((function ($tiny) {
     return $tiny < 3;
-  }), $i)) {
+  })($i)) {
     continue;
   }
   break;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,9 @@
         <testsuite name="helpers">
             <file>tests/helpers.php</file>
         </testsuite>
+        <testsuite name="array">
+            <file>tests/array.php</file>
+        </testsuite>
         <testsuite name="badSyntaxes">
             <file>tests/badSyntaxes.php</file>
             <file>tests/badSwitchSyntaxes.php</file>

--- a/src/JsPhpize/Compiler/Compiler.php
+++ b/src/JsPhpize/Compiler/Compiler.php
@@ -52,7 +52,7 @@ class Compiler
     /**
      * @var array
      */
-    protected $helpers = array();
+    protected $helpers = [];
 
     public function __construct(JsPhpize $engine)
     {
@@ -131,12 +131,12 @@ class Compiler
             $set = $this->engine->getHelperName('set');
 
             while ($lastChild = $assignation->leftHand->popChild()) {
-                $rightHand = $this->helperWrap($set, array(
+                $rightHand = $this->helperWrap($set, [
                     $this->visitNode($assignation->leftHand, $indent),
                     $this->visitNode($lastChild, $indent),
                     var_export($assignation->operator, true),
                     $rightHand,
-                ));
+                ]);
             }
         }
 
@@ -170,7 +170,7 @@ class Compiler
 
     protected function visitBracketsArray(BracketsArray $array, $indent)
     {
-        $visitNode = array($this, 'visitNode');
+        $visitNode = [$this, 'visitNode'];
 
         return $this->arrayWrap(implode(', ', array_map(
             function ($pair) use ($visitNode, $indent) {
@@ -192,7 +192,7 @@ class Compiler
         }
         if ($constant->type === 'regexp') {
             $regExp = $this->engine->getHelperName('regExp');
-            $value = $this->helperWrap($regExp, array(var_export($value, true)));
+            $value = $this->helperWrap($regExp, [var_export($value, true)]);
         }
 
         return $value;
@@ -203,7 +203,7 @@ class Compiler
         $leftHand = $this->visitNode($dyiade->leftHand, $indent);
         $rightHand = $this->visitNode($dyiade->rightHand, $indent);
         if ($dyiade->operator === '+') {
-            $arguments = array($leftHand, $rightHand);
+            $arguments = [$leftHand, $rightHand];
             while (
                 ($dyiade = $dyiade->rightHand) instanceof Dyiade &&
                 $dyiade->operator === '+'
@@ -223,7 +223,7 @@ class Compiler
 
     protected function mapNodesArray($array, $indent, $pattern = null)
     {
-        $visitNode = array($this, 'visitNode');
+        $visitNode = [$this, 'visitNode'];
 
         return array_map(function ($value) use ($visitNode, $indent, $pattern) {
             $value = $visitNode($value, $indent);
@@ -253,7 +253,7 @@ class Compiler
             $name = $function->name;
             $staticCall = $name . '(' . $arguments . ')';
 
-            $functions = str_replace(array("\n", "\t", "\r", ' '), '', static::STATIC_CALL_FUNCTIONS);
+            $functions = str_replace(["\n", "\t", "\r", ' '], '', static::STATIC_CALL_FUNCTIONS);
             if ($applicant === 'new' || in_array($name, explode(',', $functions))) {
                 return $staticCall;
             }
@@ -273,7 +273,7 @@ class Compiler
 
     protected function visitInstruction(Instruction $group, $indent)
     {
-        $visitNode = array($this, 'visitNode');
+        $visitNode = [$this, 'visitNode'];
         $isReturnPrepended = $group->isReturnPrepended();
 
         return implode('', array_map(function ($instruction) use ($visitNode, $indent, $isReturnPrepended) {

--- a/src/JsPhpize/Compiler/Compiler.php
+++ b/src/JsPhpize/Compiler/Compiler.php
@@ -20,6 +20,8 @@ use JsPhpize\Nodes\Variable;
 
 class Compiler
 {
+    use DependenciesTrait;
+
     /**
      * @const string
      */
@@ -35,85 +37,20 @@ class Compiler
     protected $engine;
 
     /**
-     * @var string
-     */
-    protected $varPrefix;
-
-    /**
-     * @var string
-     */
-    protected $constPrefix;
-
-    /**
      * @var bool
      */
     protected $arrayShortSyntax;
 
-    /**
-     * @var array
-     */
-    protected $helpers = [];
-
     public function __construct(JsPhpize $engine)
     {
         $this->engine = $engine;
-        $this->varPrefix = $engine->getVarPrefix();
-        $this->constPrefix = $engine->getConstPrefix();
+        $this->setPrefixes($engine->getVarPrefix(), $engine->getConstPrefix());
         $this->arrayShortSyntax = $engine->getOption('arrayShortSyntax', false);
-    }
-
-    protected function helperWrap($helper, $arguments)
-    {
-        $this->helpers[$helper] = true;
-
-        if (isset($arguments[0]) && preg_match('/^\$.*[^)]$/', $arguments[0])) {
-            $helper .= '_with_ref';
-        }
-
-        return '$GLOBALS[\'' . $this->varPrefix . $helper . '\'](' .
-            implode(', ', $arguments) .
-        ')';
     }
 
     protected function arrayWrap($arrayBody)
     {
         return sprintf($this->arrayShortSyntax ? '[ %s ]' : 'array( %s )', $arrayBody);
-    }
-
-    public function getDependencies()
-    {
-        return array_keys($this->helpers);
-    }
-
-    public function compileDependencies($dependencies)
-    {
-        $php = '';
-
-        foreach ($dependencies as $name) {
-            $file = preg_match('/^[a-z0-9_-]+$/i', $name)
-                ? __DIR__ . '/Helpers/' . ucfirst($name) . '.h'
-                : $name;
-
-            $code = file_exists($file)
-                ? file_get_contents($file)
-                : $name;
-
-            $php .= '$GLOBALS[\'' . $this->varPrefix . $name . '\'] = ' .
-                trim($code) .
-                ";\n";
-
-            $refFile = preg_replace('/\.h$/', '.ref.h', $file);
-
-            $code = $refFile !== $file && file_exists($refFile)
-                ? file_get_contents($refFile)
-                : '$GLOBALS[\'' . $this->varPrefix . $name . '\']';
-
-            $php .= '$GLOBALS[\'' . $this->varPrefix . $name . '_with_ref\'] = ' .
-                trim($code) .
-                ";\n";
-        }
-
-        return $php;
     }
 
     protected function visitAssignation(Assignation $assignation, $indent)

--- a/src/JsPhpize/Compiler/DependenciesTrait.php
+++ b/src/JsPhpize/Compiler/DependenciesTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace JsPhpize\Compiler;
+
+trait DependenciesTrait
+{
+    /**
+     * @var string
+     */
+    protected $varPrefix;
+
+    /**
+     * @var string
+     */
+    protected $constPrefix;
+
+    /**
+     * @var array
+     */
+    protected $helpers = [];
+
+    protected function setPrefixes($varPrefix, $constPrefix)
+    {
+        $this->varPrefix = $varPrefix;
+        $this->constPrefix = $constPrefix;
+    }
+
+    protected function helperWrap($helper, $arguments)
+    {
+        $this->helpers[$helper] = true;
+
+        if (isset($arguments[0]) && preg_match('/^\$.*[^)]$/', $arguments[0])) {
+            $helper .= '_with_ref';
+        }
+
+        return '$GLOBALS[\'' . $this->varPrefix . $helper . '\'](' .
+            implode(', ', $arguments) .
+            ')';
+    }
+
+    public function getDependencies()
+    {
+        return array_keys($this->helpers);
+    }
+
+    public function compileDependencies($dependencies)
+    {
+        $php = '';
+
+        foreach ($dependencies as $name) {
+            $file = preg_match('/^[a-z0-9_-]+$/i', $name)
+                ? __DIR__ . '/Helpers/' . ucfirst($name) . '.h'
+                : $name;
+
+            $code = file_exists($file)
+                ? file_get_contents($file)
+                : $name;
+
+            $php .= '$GLOBALS[\'' . $this->varPrefix . $name . '\'] = ' .
+                trim($code) .
+                ";\n";
+
+            $refFile = preg_replace('/\.h$/', '.ref.h', $file);
+
+            $code = $refFile !== $file && file_exists($refFile)
+                ? file_get_contents($refFile)
+                : '$GLOBALS[\'' . $this->varPrefix . $name . '\']';
+
+            $php .= '$GLOBALS[\'' . $this->varPrefix . $name . '_with_ref\'] = ' .
+                trim($code) .
+                ";\n";
+        }
+
+        return $php;
+    }
+}

--- a/src/JsPhpize/Compiler/Helpers/Dot.ref.h
+++ b/src/JsPhpize/Compiler/Helpers/Dot.ref.h
@@ -1,0 +1,106 @@
+function (&$base) {
+    $getFromArray = function (&$base, $key) {
+        return isset($base[$key])
+            ? $base[$key]
+            : null;
+    };
+    $getCallable = function (&$base, $key) use ($getFromArray) {
+        if (is_callable(array($base, $key))) {
+            return array($base, $key);
+        }
+        if ($base instanceof \ArrayAccess) {
+            return $getFromArray($base, $key);
+        }
+    };
+    $getRegExp = function ($value) {
+        return isset($value->isRegularExpression) && $value->isRegularExpression ? $value->regExp : null;
+    };
+    $fallbackDot = function (&$base, $key) use ($getCallable, $getRegExp) {
+        if (is_string($base)) {
+            if (preg_match('/^[-+]?\d+$/', strval($key))) {
+                return substr($base, intval($key), 1);
+            }
+            if ($key === 'length') {
+                return strlen($base);
+            }
+            if ($key === 'substr' || $key === 'slice') {
+                return function ($start, $length = null) use ($base) {
+                    return func_num_args() === 1 ? substr($base, $start) : substr($base, $start, $length);
+                };
+            }
+            if ($key === 'charAt') {
+                return function ($pos) use ($base) {
+                    return substr($base, $pos, 1);
+                };
+            }
+            if ($key === 'indexOf') {
+                return function ($needle) use ($base) {
+                    $pos = strpos($base, $needle);
+
+                    return $pos === false ? -1 : $pos;
+                };
+            }
+            if ($key === 'toUpperCase') {
+                return function () use ($base) {
+                    return strtoupper($base);
+                };
+            }
+            if ($key === 'toLowerCase') {
+                return function () use ($base) {
+                    return strtolower($base);
+                };
+            }
+            if ($key === 'match') {
+                return function ($search) use ($base, $getRegExp) {
+                    if (!$getRegExp($search)) {
+                        $search = '/' . preg_quote($search) . '/';
+                    }
+
+                    return preg_match($search, $base);
+                };
+            }
+            if ($key === 'split') {
+                return function ($delimiter) use ($base, $getRegExp) {
+                    if ($regExp = $getRegExp($delimiter)) {
+                        return preg_split($regExp, $base);
+                    }
+
+                    return explode($delimiter, $base);
+                };
+            }
+            if ($key === 'replace') {
+                return function ($from, $to) use ($base, $getRegExp) {
+                    if ($regExp = $getRegExp($from)) {
+                        return preg_replace($regExp, $to, $base);
+                    }
+
+                    return str_replace($from, $to, $base);
+                };
+            }
+        }
+
+        return $getCallable($base, $key);
+    };
+    $crawler = &$base;
+    $result = $base;
+    foreach (array_slice(func_get_args(), 1) as $key) {
+        $result = is_array($crawler)
+            ? $getFromArray($crawler, $key)
+            : (is_object($crawler)
+                ? (isset($crawler->$key)
+                    ? $crawler->$key
+                    : (method_exists($crawler, $method = "get" . ucfirst($key))
+                        ? $crawler->$method()
+                        : (method_exists($crawler, $key)
+                            ? array($crawler, $key)
+                            : $getCallable($crawler, $key)
+                        )
+                    )
+                )
+                : $fallbackDot($crawler, $key)
+            );
+        $crawler = &$result;
+    }
+
+    return $result;
+}

--- a/src/JsPhpize/Compiler/Helpers/DotObject.ref.h
+++ b/src/JsPhpize/Compiler/Helpers/DotObject.ref.h
@@ -1,0 +1,103 @@
+function (&$base) {
+    $getFromArray = function (&$base, $key) {
+        return isset($base[$key])
+            ? $base[$key]
+            : null;
+    };
+    $getCallable = function (&$base, $key) use ($getFromArray) {
+        if (is_callable(array($base, $key))) {
+            return array($base, $key);
+        }
+        if ($base instanceof \ArrayAccess) {
+            return $getFromArray($base, $key);
+        }
+    };
+    $getRegExp = function ($value) {
+        return isset($value->isRegularExpression) && $value->isRegularExpression ? $value->regExp : null;
+    };
+    $fallbackDot = function (&$base, $key) use ($getCallable, $getRegExp) {
+        if (is_string($base)) {
+            if (preg_match('/^[-+]?\d+$/', strval($key))) {
+                return substr($base, intval($key), 1);
+            }
+            if ($key === 'length') {
+                return strlen($base);
+            }
+            if ($key === 'substr' || $key === 'slice') {
+                return function ($start, $length = null) use ($base) {
+                    return func_num_args() === 1 ? substr($base, $start) : substr($base, $start, $length);
+                };
+            }
+            if ($key === 'charAt') {
+                return function ($pos) use ($base) {
+                    return substr($base, $pos, 1);
+                };
+            }
+            if ($key === 'indexOf') {
+                return function ($needle) use ($base) {
+                    $pos = strpos($base, $needle);
+
+                    return $pos === false ? -1 : $pos;
+                };
+            }
+            if ($key === 'toUpperCase') {
+                return function () use ($base) {
+                    return strtoupper($base);
+                };
+            }
+            if ($key === 'toLowerCase') {
+                return function () use ($base) {
+                    return strtolower($base);
+                };
+            }
+            if ($key === 'match') {
+                return function ($search) use ($base, $getRegExp) {
+                    if (!$getRegExp($search)) {
+                        $search = '/' . preg_quote($search) . '/';
+                    }
+
+                    return preg_match($search, $base);
+                };
+            }
+            if ($key === 'split') {
+                return function ($delimiter) use ($base, $getRegExp) {
+                    if ($regExp = $getRegExp($delimiter)) {
+                        return preg_split($regExp, $base);
+                    }
+
+                    return explode($delimiter, $base);
+                };
+            }
+            if ($key === 'replace') {
+                return function ($from, $to) use ($base, $getRegExp) {
+                    if ($regExp = $getRegExp($from)) {
+                        return preg_replace($regExp, $to, $base);
+                    }
+
+                    return str_replace($from, $to, $base);
+                };
+            }
+        }
+
+        return $getCallable($base, $key);
+    };
+    $crawler = &$base;
+    $result = $base;
+    foreach (array_slice(func_get_args(), 1) as $key) {
+        $result = is_array($crawler)
+            ? $getFromArray($crawler, $key)
+            : (is_object($crawler)
+                ? (method_exists($crawler, $method = "get" . ucfirst($key))
+                    ? $crawler->$method()
+                    : (method_exists($crawler, $key)
+                        ? array($crawler, $key)
+                        : $crawler->$key
+                    )
+                )
+                : $fallbackDot($crawler, $key)
+            );
+        $crawler = &$result;
+    }
+
+    return $result;
+}

--- a/src/JsPhpize/Compiler/Helpers/DotWithArrayPrototype.ref.h
+++ b/src/JsPhpize/Compiler/Helpers/DotWithArrayPrototype.ref.h
@@ -1,0 +1,185 @@
+function (&$base) {
+    $arrayPrototype = function (&$base, $key) {
+        if ($key === 'length') {
+            return count($base);
+        }
+        if ($key === 'forEach') {
+            return function ($callback, $userData = null) use (&$base) {
+                return array_walk($base, $callback, $userData);
+            };
+        }
+        if ($key === 'map') {
+            return function ($callback) use (&$base) {
+                return array_map($callback, $base);
+            };
+        }
+        if ($key === 'filter') {
+            return function ($callback, $flag = 0) use ($base) {
+                return func_num_args() === 1 ? array_filter($base, $callback) : array_filter($base, $callback, $flag);
+            };
+        }
+        if ($key === 'pop') {
+            return function () use (&$base) {
+                return array_pop($base);
+            };
+        }
+        if ($key === 'shift') {
+            return function () use (&$base) {
+                return array_shift($base);
+            };
+        }
+        if ($key === 'push') {
+            return function ($item) use (&$base) {
+                return array_push($base, $item);
+            };
+        }
+        if ($key === 'unshift') {
+            return function ($item) use (&$base) {
+                return array_unshift($base, $item);
+            };
+        }
+        if ($key === 'indexOf') {
+            return function ($item) use (&$base) {
+                $search = array_search($item, $base);
+
+                return $search === false ? -1 : $search;
+            };
+        }
+        if ($key === 'slice') {
+            return function ($offset, $length = null, $preserveKeys = false) use (&$base) {
+                return array_slice($base, $offset, $length, $preserveKeys);
+            };
+        }
+        if ($key === 'splice') {
+            return function ($offset, $length = null, $replacements = array()) use (&$base) {
+                return array_splice($base, $offset, $length, $replacements);
+            };
+        }
+        if ($key === 'reverse') {
+            return function () use (&$base) {
+                return array_reverse($base);
+            };
+        }
+        if ($key === 'reduce') {
+            return function ($callback, $initial = null) use (&$base) {
+                return array_reduce($base, $callback, $initial);
+            };
+        }
+        if ($key === 'join') {
+            return function ($glue) use (&$base) {
+                return implode($glue, $base);
+            };
+        }
+        if ($key === 'sort') {
+            return function ($callback = null) use (&$base) {
+                return $callback ? usort($base, $callback) : sort($base);
+            };
+        }
+
+        return null;
+    };
+    $getFromArray = function (&$base, $key) use ($arrayPrototype) {
+        return isset($base[$key])
+            ? $base[$key]
+            : $arrayPrototype($base, $key);
+    };
+    $getCallable = function (&$base, $key) use ($getFromArray) {
+        if (is_callable(array($base, $key))) {
+            return array($base, $key);
+        }
+        if ($base instanceof \ArrayAccess) {
+            return $getFromArray($base, $key);
+        }
+    };
+    $getRegExp = function ($value) {
+        return isset($value->isRegularExpression) && $value->isRegularExpression ? $value->regExp : null;
+    };
+    $fallbackDot = function (&$base, $key) use ($getCallable, $getRegExp) {
+        if (is_string($base)) {
+            if (preg_match('/^[-+]?\d+$/', strval($key))) {
+                return substr($base, intval($key), 1);
+            }
+            if ($key === 'length') {
+                return strlen($base);
+            }
+            if ($key === 'substr' || $key === 'slice') {
+                return function ($start, $length = null) use ($base) {
+                    return func_num_args() === 1 ? substr($base, $start) : substr($base, $start, $length);
+                };
+            }
+            if ($key === 'charAt') {
+                return function ($pos) use ($base) {
+                    return substr($base, $pos, 1);
+                };
+            }
+            if ($key === 'indexOf') {
+                return function ($needle) use ($base) {
+                    $pos = strpos($base, $needle);
+
+                    return $pos === false ? -1 : $pos;
+                };
+            }
+            if ($key === 'toUpperCase') {
+                return function () use ($base) {
+                    return strtoupper($base);
+                };
+            }
+            if ($key === 'toLowerCase') {
+                return function () use ($base) {
+                    return strtolower($base);
+                };
+            }
+            if ($key === 'match') {
+                return function ($search) use ($base, $getRegExp) {
+                    if (!$getRegExp($search)) {
+                        $search = '/' . preg_quote($search) . '/';
+                    }
+
+                    return preg_match($search, $base);
+                };
+            }
+            if ($key === 'split') {
+                return function ($delimiter) use ($base, $getRegExp) {
+                    if ($regExp = $getRegExp($delimiter)) {
+                        return preg_split($regExp, $base);
+                    }
+
+                    return explode($delimiter, $base);
+                };
+            }
+            if ($key === 'replace') {
+                return function ($from, $to) use ($base, $getRegExp) {
+                    if ($regExp = $getRegExp($from)) {
+                        return preg_replace($regExp, $to, $base);
+                    }
+
+                    return str_replace($from, $to, $base);
+                };
+            }
+        }
+
+        return $getCallable($base, $key);
+    };
+    $crawler = &$base;
+    $result = $base;
+    foreach (array_slice(func_get_args(), 1) as $key) {
+        $result = is_array($crawler)
+            ? $getFromArray($crawler, $key)
+            : (is_object($crawler)
+                ? (isset($crawler->$key)
+                    ? $crawler->$key
+                    : (method_exists($crawler, $method = "get" . ucfirst($key))
+                        ? $crawler->$method()
+                        : (method_exists($crawler, $key)
+                            ? array($crawler, $key)
+                            : $getCallable($crawler, $key)
+                        )
+                    )
+                )
+                : $fallbackDot($crawler, $key)
+            );
+        $crawler = &$result;
+    }
+
+    return $result;
+}

--- a/src/JsPhpize/JsPhpize.php
+++ b/src/JsPhpize/JsPhpize.php
@@ -16,22 +16,22 @@ class JsPhpize extends JsPhpizeOptions
     /**
      * @var array
      */
-    protected $streamsRegistered = array();
+    protected $streamsRegistered = [];
 
     /**
      * @var array
      */
-    protected $options = array();
+    protected $options = [];
 
     /**
      * @var array
      */
-    protected $dependencies = array();
+    protected $dependencies = [];
 
     /**
      * @var array
      */
-    protected $sharedVariables = array();
+    protected $sharedVariables = [];
 
     /**
      * Compile file or code (detect if $input is an exisisting file, else use it as content).
@@ -72,7 +72,7 @@ class JsPhpize extends JsPhpizeOptions
         $dependencies = $compiler->getDependencies();
         if ($this->getOption('catchDependencies')) {
             $this->dependencies = array_unique(array_merge($this->dependencies, $dependencies));
-            $dependencies = array();
+            $dependencies = [];
         }
 
         $php = $compiler->compileDependencies($dependencies) . $start . $php . $end;
@@ -123,7 +123,7 @@ class JsPhpize extends JsPhpizeOptions
      */
     public function flushDependencies()
     {
-        $this->dependencies = array();
+        $this->dependencies = [];
 
         return $this;
     }
@@ -137,7 +137,7 @@ class JsPhpize extends JsPhpizeOptions
      *
      * @return mixed
      */
-    public function render($input, $filename = null, array $variables = array())
+    public function render($input, $filename = null, array $variables = [])
     {
         if (is_array($filename)) {
             $variables = $filename;
@@ -187,7 +187,7 @@ class JsPhpize extends JsPhpizeOptions
      *
      * @return string
      */
-    public function renderFile($file, array $variables = array())
+    public function renderFile($file, array $variables = [])
     {
         return $this->render(file_get_contents($file), $file, $variables);
     }
@@ -200,7 +200,7 @@ class JsPhpize extends JsPhpizeOptions
      *
      * @return string
      */
-    public function renderCode($code, array $variables = array())
+    public function renderCode($code, array $variables = [])
     {
         return $this->render($code, 'source.js', $variables);
     }
@@ -219,7 +219,7 @@ class JsPhpize extends JsPhpizeOptions
     public function share($variables, $value = null)
     {
         if (!is_array($variables)) {
-            $variables = array(strval($variables) => $value);
+            $variables = [strval($variables) => $value];
         }
         $this->sharedVariables = array_merge($this->sharedVariables, $variables);
     }
@@ -229,6 +229,6 @@ class JsPhpize extends JsPhpizeOptions
      */
     public function resetSharedVariables()
     {
-        $this->sharedVariables = array();
+        $this->sharedVariables = [];
     }
 }

--- a/src/JsPhpize/JsPhpizeOptions.php
+++ b/src/JsPhpize/JsPhpizeOptions.php
@@ -36,38 +36,38 @@ class JsPhpizeOptions
     /**
      * @var array
      */
-    protected $patternsCache = array();
+    protected $patternsCache = [];
 
     /**
      * Pass options as array or no parameters for all options on default value.
      *
      * @param array|ArrayAccess $options list of options.
      */
-    public function __construct($options = array())
+    public function __construct($options = [])
     {
-        $this->options = is_array($options) || $options instanceof ArrayAccess ? $options : array();
+        $this->options = is_array($options) || $options instanceof ArrayAccess ? $options : [];
         if (!isset($this->options['patterns'])) {
-            $this->options['patterns'] = array(
+            $this->options['patterns'] = [
                 new Pattern(10, 'newline', '\n'),
                 new Pattern(20, 'comment', '\/\/.*?\n|\/\*[\s\S]*?\*\/'),
                 new Pattern(30, 'string', '"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\''),
                 new Pattern(40, 'number', '0[bB][01]+|0[oO][0-7]+|0[xX][0-9a-fA-F]+|(\d+(\.\d*)?|\.\d+)([eE]-?\d+)?'),
                 new Pattern(50, 'lambda', '=>'),
-                new Pattern(60, 'operator', array('delete', 'typeof', 'void'), true),
-                new Pattern(65, 'unexpected', array('::')),
-                new Pattern(70, 'operator', array('>>>=', '<<=', '>>=', '**=')),
-                new Pattern(80, 'operator', array('++', '--', '&&', '||', '**', '>>>', '<<', '>>')),
-                new Pattern(90, 'operator', array('===', '!==', '>=', '<=', '<>', '!=', '==', '>', '<')),
+                new Pattern(60, 'operator', ['delete', 'typeof', 'void'], true),
+                new Pattern(65, 'unexpected', ['::']),
+                new Pattern(70, 'operator', ['>>>=', '<<=', '>>=', '**=']),
+                new Pattern(80, 'operator', ['++', '--', '&&', '||', '**', '>>>', '<<', '>>']),
+                new Pattern(90, 'operator', ['===', '!==', '>=', '<=', '<>', '!=', '==', '>', '<']),
                 new Pattern(95, 'regexp', '\/(?:\\\\\S|[^\s\/\\\\])*\/[gimuy]*'),
                 new Pattern(100, 'operator', '[\\|\\^&%\\/\\*\\+\\-]='),
                 new Pattern(110, 'operator', '[\\[\\]\\{\\}\\(\\)\\:\\.\\/\\*~\\!\\^\\|&%\\?,;\\+\\-]'),
-                new Pattern(120, 'keyword', array('as', 'async', 'await', 'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default', 'do', 'else', 'enum', 'export', 'extends', 'finally', 'for', 'from', 'function', 'get', 'if', 'implements', 'import', 'in', 'instanceof', 'interface', 'let', 'new', 'of', 'package', 'private', 'protected', 'public', 'return', 'set', 'static', 'super', 'switch', 'throw', 'try', 'var', 'while', 'with', 'yield', 'yield*'), true),
+                new Pattern(120, 'keyword', ['as', 'async', 'await', 'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default', 'do', 'else', 'enum', 'export', 'extends', 'finally', 'for', 'from', 'function', 'get', 'if', 'implements', 'import', 'in', 'instanceof', 'interface', 'let', 'new', 'of', 'package', 'private', 'protected', 'public', 'return', 'set', 'static', 'super', 'switch', 'throw', 'try', 'var', 'while', 'with', 'yield', 'yield*'], true),
                 new Pattern(130, 'constant', 'null|undefined|Infinity|NaN|true|false|Math\.[A-Z][A-Z0-9_]*' . (isset($this->options['disableConstants']) && $this->options['disableConstants']
                     ? ''
                     : '|[A-Z][A-Z0-9\\\\_\\x7f-\\xff]*|[\\\\\\x7f-\\xff_][A-Z0-9\\\\_\\x7f-\\xff]*[A-Z][A-Z0-9\\\\_\\x7f-\\xff]*'), true),
                 new Pattern(135, 'variable', '[a-zA-Z\\\\\\x7f-\\xff\\$_][a-zA-Z0-9\\\\_\\x7f-\\xff\\$]*', '$'),
                 new Pattern(140, 'operator', '[\\s\\S]'),
-            );
+            ];
         }
     }
 
@@ -162,7 +162,7 @@ class JsPhpizeOptions
      */
     public function getHelperName($key)
     {
-        $helpers = $this->getOption('helpers', array());
+        $helpers = $this->getOption('helpers', []);
 
         return is_array($helpers) && isset($helpers[$key])
             ? $helpers[$key]

--- a/src/JsPhpize/Lexer/DataBag.php
+++ b/src/JsPhpize/Lexer/DataBag.php
@@ -11,14 +11,14 @@ class DataBag
 
     public function __construct($type, array $data)
     {
-        $this->data = array_merge(array(
+        $this->data = array_merge([
             'type' => $type,
-        ), $data);
+        ], $data);
     }
 
     public function is($value)
     {
-        return in_array($value, array($this->type, $this->value));
+        return in_array($value, [$this->type, $this->value]);
     }
 
     protected function typeIn($values)

--- a/src/JsPhpize/Lexer/Lexer.php
+++ b/src/JsPhpize/Lexer/Lexer.php
@@ -41,7 +41,7 @@ class Lexer extends Scanner
         $this->engine = $engine;
         $this->filename = $filename;
         $this->line = 1;
-        $disallow = $engine->getOption('disallow', array());
+        $disallow = $engine->getOption('disallow', []);
         if (is_string($disallow)) {
             $disallow = explode(' ', $disallow);
         }
@@ -69,11 +69,11 @@ class Lexer extends Scanner
         $this->input = mb_substr($this->input, mb_strlen($consumed));
     }
 
-    protected function token($type, $data = array())
+    protected function token($type, $data = [])
     {
         $className = $this->engine->getOption('tokenClass', '\\JsPhpize\\Lexer\\Token');
 
-        return new $className($type, is_string($data) ? array('value' => $data) : (array) $data);
+        return new $className($type, is_string($data) ? ['value' => $data] : (array) $data);
     }
 
     protected function typeToken($matches)

--- a/src/JsPhpize/Lexer/Scanner.php
+++ b/src/JsPhpize/Lexer/Scanner.php
@@ -29,11 +29,11 @@ class Scanner
             throw new Exception('Constants cannot start with ' . $constPrefix . ', this prefix is reserved for JsPhpize' . $this->exceptionInfos(), 1);
         }
 
-        $translate = array(
+        $translate = [
             'Infinity' => 'INF',
             'NaN' => 'NAN',
             'undefined' => 'null',
-        );
+        ];
 
         if (isset($translate[$constant])) {
             $constant = $translate[$constant];

--- a/src/JsPhpize/Lexer/Token.php
+++ b/src/JsPhpize/Lexer/Token.php
@@ -13,42 +13,42 @@ class Token extends DataBag
 
     public function isValue()
     {
-        return $this->typeIn(array('variable', 'constant', 'string', 'number', 'regexp'));
+        return $this->typeIn(['variable', 'constant', 'string', 'number', 'regexp']);
     }
 
     public function isValidMember()
     {
-        return $this->typeIn(array('variable', 'keyword'));
+        return $this->typeIn(['variable', 'keyword']);
     }
 
     protected function isComparison()
     {
-        return $this->typeIn(array('===', '!==', '>=', '<=', '<>', '!=', '==', '>', '<'));
+        return $this->typeIn(['===', '!==', '>=', '<=', '<>', '!=', '==', '>', '<']);
     }
 
     protected function isLogical()
     {
-        return $this->typeIn(array('&&', '||', '!'));
+        return $this->typeIn(['&&', '||', '!']);
     }
 
     protected function isBinary()
     {
-        return $this->typeIn(array('&', '|', '^', '~', '>>', '<<', '>>>'));
+        return $this->typeIn(['&', '|', '^', '~', '>>', '<<', '>>>']);
     }
 
     protected function isArithmetic()
     {
-        return $this->typeIn(array('+', '-', '/', '*', '%', '**', '--', '++'));
+        return $this->typeIn(['+', '-', '/', '*', '%', '**', '--', '++']);
     }
 
     protected function isVarOperator()
     {
-        return $this->typeIn(array('delete', 'void', 'typeof'));
+        return $this->typeIn(['delete', 'void', 'typeof']);
     }
 
     public function isLeftHandOperator()
     {
-        return $this->typeIn(array('~', '!', '--', '++', '-', '+')) || $this->isVarOperator();
+        return $this->typeIn(['~', '!', '--', '++', '-', '+']) || $this->isVarOperator();
     }
 
     public function isAssignation()
@@ -63,12 +63,12 @@ class Token extends DataBag
 
     public function isNeutral()
     {
-        return $this->typeIn(array('comment', 'newline'));
+        return $this->typeIn(['comment', 'newline']);
     }
 
     public function expectNoLeftMember()
     {
-        return in_array($this->type, array('!', '~')) || $this->isVarOperator();
+        return in_array($this->type, ['!', '~']) || $this->isVarOperator();
     }
 
     public function isFunction()

--- a/src/JsPhpize/Nodes/ArrayBase.php
+++ b/src/JsPhpize/Nodes/ArrayBase.php
@@ -4,5 +4,5 @@ namespace JsPhpize\Nodes;
 
 abstract class ArrayBase extends Value
 {
-    protected $data = array();
+    protected $data = [];
 }

--- a/src/JsPhpize/Nodes/ArrayBase.php
+++ b/src/JsPhpize/Nodes/ArrayBase.php
@@ -2,6 +2,11 @@
 
 namespace JsPhpize\Nodes;
 
+/**
+ * Class ArrayBase.
+ *
+ * @property-read array $data array elements
+ */
 abstract class ArrayBase extends Value
 {
     protected $data = [];

--- a/src/JsPhpize/Nodes/Assignation.php
+++ b/src/JsPhpize/Nodes/Assignation.php
@@ -4,6 +4,13 @@ namespace JsPhpize\Nodes;
 
 use JsPhpize\Parser\Exception;
 
+/**
+ * Class Assignation.
+ *
+ * @property-read Assignable $leftHand  left hand assignation slot
+ * @property-read Node       $rightHand right hand assigned value
+ * @property-read string     $operator  assignation operator
+ */
 class Assignation extends Value
 {
     /**
@@ -12,7 +19,7 @@ class Assignation extends Value
     protected $leftHand;
 
     /**
-     * @var Value
+     * @var Node
      */
     protected $rightHand;
 
@@ -21,6 +28,15 @@ class Assignation extends Value
      */
     protected $operator;
 
+    /**
+     * Assignation constructor.
+     *
+     * @param string     $operator
+     * @param Assignable $leftHand
+     * @param Node       $rightHand
+     *
+     * @throws Exception
+     */
     public function __construct($operator, Assignable $leftHand, Node $rightHand)
     {
         $reason = $leftHand->getNonAssignableReason();
@@ -37,7 +53,7 @@ class Assignation extends Value
     public function getReadVariables()
     {
         return array_merge(
-            $this->leftHand->getReadVariables(),
+            method_exists($this->leftHand, 'getReadVariables') ? $this->leftHand->getReadVariables() : [],
             $this->rightHand->getReadVariables()
         );
     }

--- a/src/JsPhpize/Nodes/Block.php
+++ b/src/JsPhpize/Nodes/Block.php
@@ -2,6 +2,16 @@
 
 namespace JsPhpize\Nodes;
 
+/**
+ * Class Constant.
+ *
+ * @property-read Node   $value                block parenthesis or inline content
+ * @property-read array  $instructions         block body (list of instructions)
+ * @property-read string $type                 block type
+ * @property-read bool   $inInstruction        true if the block is in an Instruction instance
+ * @property-read bool   $multipleInstructions true if the block contains more than one instruction
+ * @property-read array  $letVariables         true if the block contains more than one instruction
+ */
 class Block extends Node
 {
     /**

--- a/src/JsPhpize/Nodes/Block.php
+++ b/src/JsPhpize/Nodes/Block.php
@@ -32,12 +32,12 @@ class Block extends Node
     /**
      * @var array
      */
-    protected $letVariables = array();
+    protected $letVariables = [];
 
     public function __construct($type)
     {
         $this->type = $type;
-        $this->instructions = array();
+        $this->instructions = [];
         $this->inInstruction = false;
     }
 
@@ -51,7 +51,7 @@ class Block extends Node
         $scope = $this;
 
         return array_map(function ($name) use ($scope) {
-            $variable = new Variable($name, array());
+            $variable = new Variable($name, []);
             $variable->setScope($scope);
 
             return $variable;
@@ -65,7 +65,7 @@ class Block extends Node
 
     public function handleInstructions()
     {
-        return $this->needParenthesis() || in_array($this->type, array(
+        return $this->needParenthesis() || in_array($this->type, [
             'main',
             'else',
             'try',
@@ -74,19 +74,19 @@ class Block extends Node
             'interface',
             'class',
             'switch',
-        ));
+        ]);
     }
 
     public function needParenthesis()
     {
-        return in_array($this->type, array(
+        return in_array($this->type, [
             'if',
             'elseif',
             'catch',
             'for',
             'while',
             'function',
-        ));
+        ]);
     }
 
     public function addInstructions($instructions)
@@ -135,7 +135,7 @@ class Block extends Node
         }
         $variables = array_unique($variables);
         if ($this->type === 'function') {
-            $nodes = isset($this->value, $this->value->nodes) ? $this->value->nodes : array();
+            $nodes = isset($this->value, $this->value->nodes) ? $this->value->nodes : [];
             if (count($nodes)) {
                 $nodes = array_map(function ($node) {
                     return $node instanceof Variable ? $node->name : null;

--- a/src/JsPhpize/Nodes/BracketsArray.php
+++ b/src/JsPhpize/Nodes/BracketsArray.php
@@ -6,12 +6,12 @@ class BracketsArray extends ArrayBase
 {
     public function addItem(Constant $key, Node $value)
     {
-        $this->data[] = array($key, $value);
+        $this->data[] = [$key, $value];
     }
 
     public function getReadVariables()
     {
-        $variables = array();
+        $variables = [];
         foreach ($this->data as $data) {
             $variables = array_merge($variables, $data[1]->getReadVariables());
         }

--- a/src/JsPhpize/Nodes/Constant.php
+++ b/src/JsPhpize/Nodes/Constant.php
@@ -4,6 +4,12 @@ namespace JsPhpize\Nodes;
 
 use JsPhpize\Parser\Exception;
 
+/**
+ * Class Constant.
+ *
+ * @property-read string $value raw value
+ * @property-read string $type  constant type
+ */
 class Constant extends Value implements Assignable
 {
     /**
@@ -16,6 +22,14 @@ class Constant extends Value implements Assignable
      */
     protected $value;
 
+    /**
+     * Constant constructor.
+     *
+     * @param $type
+     * @param $value
+     *
+     * @throws Exception
+     */
     public function __construct($type, $value)
     {
         if (!in_array($type, ['constant', 'number', 'string', 'regexp'])) {

--- a/src/JsPhpize/Nodes/Constant.php
+++ b/src/JsPhpize/Nodes/Constant.php
@@ -18,7 +18,7 @@ class Constant extends Value implements Assignable
 
     public function __construct($type, $value)
     {
-        if (!in_array($type, array('constant', 'number', 'string', 'regexp'))) {
+        if (!in_array($type, ['constant', 'number', 'string', 'regexp'])) {
             throw new Exception("The given type [$type] is not a valid constant type.", 23);
         }
         $this->type = $type;
@@ -30,7 +30,7 @@ class Constant extends Value implements Assignable
         if ($this->type !== 'constant') {
             return "{$this->type} is not assignable.";
         }
-        if (in_array($this->value, array('NAN', 'INF'))) {
+        if (in_array($this->value, ['NAN', 'INF'])) {
             return "{$this->value} is not assignable.";
         }
         if (mb_substr($this->value, 0, 2) === 'M_') {

--- a/src/JsPhpize/Nodes/Dyiade.php
+++ b/src/JsPhpize/Nodes/Dyiade.php
@@ -2,6 +2,13 @@
 
 namespace JsPhpize\Nodes;
 
+/**
+ * Class Dyiade.
+ *
+ * @property-read Value  $leftHand  left hand dyiade value
+ * @property-read Value  $rightHand right hand dyiade value
+ * @property-read string $operator  dyiade operator
+ */
 class Dyiade extends Value
 {
     /**

--- a/src/JsPhpize/Nodes/DynamicValue.php
+++ b/src/JsPhpize/Nodes/DynamicValue.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JsPhpize\Nodes;
+
+/**
+ * Class DynamicValue.
+ *
+ * @property-read array $children List of sub-variables (properties of object/values of array)
+ */
+abstract class DynamicValue extends Value
+{
+    /**
+     * @var array
+     */
+    protected $children;
+
+    protected function mergeVariables(array $variables, array $nodes)
+    {
+        foreach ($nodes as $node) {
+            $variables = array_merge($variables, $node->getReadVariables());
+        }
+
+        return $variables;
+    }
+}

--- a/src/JsPhpize/Nodes/FunctionCall.php
+++ b/src/JsPhpize/Nodes/FunctionCall.php
@@ -31,7 +31,6 @@ class FunctionCall extends DynamicValue
     /**
      * FunctionCall constructor.
      *
-     *
      * @param Node        $function
      * @param array       $arguments
      * @param array       $children

--- a/src/JsPhpize/Nodes/FunctionCall.php
+++ b/src/JsPhpize/Nodes/FunctionCall.php
@@ -31,12 +31,13 @@ class FunctionCall extends DynamicValue
     /**
      * FunctionCall constructor.
      *
-     * @throws Exception
      *
      * @param Node        $function
      * @param array       $arguments
      * @param array       $children
      * @param null|string $applicant
+     *
+     * @throws Exception
      */
     public function __construct(Node $function, array $arguments, array $children, $applicant = null)
     {

--- a/src/JsPhpize/Nodes/FunctionCall.php
+++ b/src/JsPhpize/Nodes/FunctionCall.php
@@ -4,7 +4,14 @@ namespace JsPhpize\Nodes;
 
 use JsPhpize\Parser\Exception;
 
-class FunctionCall extends Value
+/**
+ * Class Value.
+ *
+ * @property-read Value|Block $function  Function body
+ * @property-read array       $arguments List the function arguments passed
+ * @property-read null|string $applicant Optional related keyword name (new, clone, ...)
+ */
+class FunctionCall extends DynamicValue
 {
     /**
      * @var Value|Block
@@ -17,15 +24,20 @@ class FunctionCall extends Value
     protected $arguments;
 
     /**
-     * @var array
-     */
-    protected $children;
-
-    /**
      * @var null|string
      */
     protected $applicant;
 
+    /**
+     * FunctionCall constructor.
+     *
+     * @throws Exception
+     *
+     * @param Node        $function
+     * @param array       $arguments
+     * @param array       $children
+     * @param null|string $applicant
+     */
     public function __construct(Node $function, array $arguments, array $children, $applicant = null)
     {
         if (!($function instanceof Value || $function instanceof Block)) {
@@ -40,11 +52,6 @@ class FunctionCall extends Value
 
     public function getReadVariables()
     {
-        $variables = $this->function->getReadVariables();
-        foreach ($this->arguments as $argument) {
-            $variables = array_merge($variables, $argument->getReadVariables());
-        }
-
-        return $variables;
+        return $this->mergeVariables($this->function->getReadVariables(), $this->arguments);
     }
 }

--- a/src/JsPhpize/Nodes/HooksArray.php
+++ b/src/JsPhpize/Nodes/HooksArray.php
@@ -13,7 +13,7 @@ class HooksArray extends ArrayBase
 
     public function getReadVariables()
     {
-        $variables = array();
+        $variables = [];
         foreach ($this->data as $value) {
             $variables = array_merge($variables, $value->getReadVariables());
         }

--- a/src/JsPhpize/Nodes/Instruction.php
+++ b/src/JsPhpize/Nodes/Instruction.php
@@ -31,7 +31,7 @@ class Instruction extends Node
 
     public function getReadVariables()
     {
-        $variables = array();
+        $variables = [];
         foreach ($this->instructions as $instruction) {
             $variables = array_merge($variables, $instruction->getReadVariables());
         }

--- a/src/JsPhpize/Nodes/Instruction.php
+++ b/src/JsPhpize/Nodes/Instruction.php
@@ -2,6 +2,12 @@
 
 namespace JsPhpize\Nodes;
 
+/**
+ * Class Instruction.
+ *
+ * @property-read array $instructions block body (list of instructions)
+ * @property-read bool  $appendReturn true if it should return the last instruction
+ */
 class Instruction extends Node
 {
     /**

--- a/src/JsPhpize/Nodes/Main.php
+++ b/src/JsPhpize/Nodes/Main.php
@@ -9,8 +9,8 @@ class Main extends Block
      */
     protected $multipleInstructions = true;
 
-    public function __construct($parentheses = null)
+    public function __construct()
     {
-        parent::__construct('main', $parentheses);
+        parent::__construct('main');
     }
 }

--- a/src/JsPhpize/Nodes/Parenthesis.php
+++ b/src/JsPhpize/Nodes/Parenthesis.php
@@ -16,7 +16,7 @@ class Parenthesis extends Value
 
     public function __construct()
     {
-        $this->nodes = array();
+        $this->nodes = [];
     }
 
     public function addNodes($nodes)
@@ -39,7 +39,7 @@ class Parenthesis extends Value
 
     public function getReadVariables()
     {
-        $variables = array();
+        $variables = [];
         foreach ($this->nodes as $node) {
             $variables = array_merge($variables, $node->getReadVariables());
         }

--- a/src/JsPhpize/Nodes/Parenthesis.php
+++ b/src/JsPhpize/Nodes/Parenthesis.php
@@ -2,6 +2,12 @@
 
 namespace JsPhpize\Nodes;
 
+/**
+ * Class Parenthesis.
+ *
+ * @property-read array  $nodes     parenthesis items
+ * @property-read string $separator string separator used between parenthesis items
+ */
 class Parenthesis extends Value
 {
     /**

--- a/src/JsPhpize/Nodes/Ternary.php
+++ b/src/JsPhpize/Nodes/Ternary.php
@@ -2,6 +2,13 @@
 
 namespace JsPhpize\Nodes;
 
+/**
+ * Class Dyiade.
+ *
+ * @property-read Value $condition  value used as ternary condition
+ * @property-read Value $trueValue  returned value if the ternary condition is truthy
+ * @property-read Value $falseValue returned value if the ternary condition is falsy
+ */
 class Ternary extends Value
 {
     /**

--- a/src/JsPhpize/Nodes/Value.php
+++ b/src/JsPhpize/Nodes/Value.php
@@ -13,12 +13,12 @@ abstract class Value extends Node
     /**
      * @var array
      */
-    protected $before = array();
+    protected $before = [];
 
     /**
      * @var array
      */
-    protected $after = array();
+    protected $after = [];
 
     public function getBefore()
     {

--- a/src/JsPhpize/Nodes/Value.php
+++ b/src/JsPhpize/Nodes/Value.php
@@ -2,6 +2,12 @@
 
 namespace JsPhpize\Nodes;
 
+/**
+ * Class Value.
+ *
+ * @property-read array $before List prefixed codes
+ * @property-read array $after  List suffixed codes
+ */
 abstract class Value extends Node
 {
     /**

--- a/src/JsPhpize/Nodes/Variable.php
+++ b/src/JsPhpize/Nodes/Variable.php
@@ -43,6 +43,6 @@ class Variable extends DynamicValue implements Assignable
 
     public function getReadVariables()
     {
-        return $this->mergeVariables(array($this->name), $this->children);
+        return $this->mergeVariables([$this->name], $this->children);
     }
 }

--- a/src/JsPhpize/Nodes/Variable.php
+++ b/src/JsPhpize/Nodes/Variable.php
@@ -2,17 +2,18 @@
 
 namespace JsPhpize\Nodes;
 
-class Variable extends Value implements Assignable
+/**
+ * Class Variable.
+ *
+ * @property-read string $name     Variable name
+ * @property-read Block  $scope    Current block scope
+ */
+class Variable extends DynamicValue implements Assignable
 {
     /**
      * @var string
      */
     protected $name;
-
-    /**
-     * @var array
-     */
-    protected $children = array();
 
     /**
      * @var Block
@@ -42,11 +43,6 @@ class Variable extends Value implements Assignable
 
     public function getReadVariables()
     {
-        $variables = array($this->name);
-        foreach ($this->children as $child) {
-            $variables = array_merge($variables, $child->getReadVariables());
-        }
-
-        return $variables;
+        return $this->mergeVariables(array($this->name), $this->children);
     }
 }

--- a/src/JsPhpize/Parser/BracketsArrayItemKey.php
+++ b/src/JsPhpize/Parser/BracketsArrayItemKey.php
@@ -24,7 +24,7 @@ class BracketsArrayItemKey
 
     protected function getStringExport($value)
     {
-        return array('string', var_export($value, true));
+        return ['string', var_export($value, true)];
     }
 
     protected function parseTypeAndValue()
@@ -43,10 +43,10 @@ class BracketsArrayItemKey
                 return $this->getStringExport($value);
             }
 
-            return array($token->type, $token->value);
+            return [$token->type, $token->value];
         }
 
-        return array(null, null);
+        return [null, null];
     }
 
     public function isValid()

--- a/src/JsPhpize/Parser/Parser.php
+++ b/src/JsPhpize/Parser/Parser.php
@@ -36,9 +36,9 @@ class Parser extends TokenExtractor
 
     public function __construct(JsPhpize $engine, $input, $filename)
     {
-        $input = str_replace(array("\r\n", "\r"), array("\n", ''), $input);
-        $this->tokens = array();
-        $this->dependencies = array();
+        $input = str_replace(["\r\n", "\r"], ["\n", ''], $input);
+        $this->tokens = [];
+        $this->dependencies = [];
         $this->engine = $engine;
         $this->lexer = new Lexer($engine, $input, $filename);
     }
@@ -182,7 +182,7 @@ class Parser extends TokenExtractor
     protected function parseFunctionCallChildren($function, $applicant = null)
     {
         $arguments = $this->parseParentheses()->nodes;
-        $children = array();
+        $children = [];
 
         while ($next = $this->get(0)) {
             if ($value = $this->getVariableChildFromToken($next)) {
@@ -208,7 +208,7 @@ class Parser extends TokenExtractor
 
     protected function parseVariable($name)
     {
-        $children = array();
+        $children = [];
         $variable = null;
         while ($next = $this->get(0)) {
             if ($next->type === 'lambda') {
@@ -430,7 +430,7 @@ class Parser extends TokenExtractor
     public function parse()
     {
         $block = new Main();
-        $this->stack = array();
+        $this->stack = [];
         $this->parseBlock($block);
 
         return $block;

--- a/src/JsPhpize/Parser/TokenExtractor.php
+++ b/src/JsPhpize/Parser/TokenExtractor.php
@@ -27,7 +27,7 @@ abstract class TokenExtractor extends TokenCrawler
             $key = new Constant($type, $value);
             $value = $this->expectValue($this->next());
 
-            return array($key, $value);
+            return [$key, $value];
         }
     }
 

--- a/src/JsPhpize/Readable.php
+++ b/src/JsPhpize/Readable.php
@@ -16,6 +16,6 @@ abstract class Readable
 
     public function getReadVariables()
     {
-        return array();
+        return [];
     }
 }

--- a/src/JsPhpize/Stream/ExpressionStream.php
+++ b/src/JsPhpize/Stream/ExpressionStream.php
@@ -74,6 +74,6 @@ class ExpressionStream
      */
     public function url_stat($path, $flags)
     {
-        return array(0, 0, 0, 0, 0, 0, 0, mb_strlen($this->data), 0, 0, 0, 0);
+        return [0, 0, 0, 0, 0, 0, 0, mb_strlen($this->data), 0, 0, 0, 0];
     }
 }

--- a/tests/array.php
+++ b/tests/array.php
@@ -7,20 +7,20 @@ class ArrayTest extends TestCase
 {
     public function caseProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 1,
                 'var a = []; return a.push(4);',
-            ),
-            array(
+            ],
+            [
                 2,
                 'var a = []; a.push(4); return a.push(4);',
-            ),
-            array(
-                array(4),
+            ],
+            [
+                [4],
                 'var a = []; a.push(4); return a;',
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -29,11 +29,11 @@ class ArrayTest extends TestCase
      */
     public function testArrayResult($expected, $code)
     {
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'dot' => 'dotWithArrayPrototype',
-            ),
-        ));
+            ],
+        ]);
         $actual = $jsPhpize->render($code);
 
         $this->assertSame($expected, $actual);

--- a/tests/array.php
+++ b/tests/array.php
@@ -1,0 +1,41 @@
+<?php
+
+use JsPhpize\JsPhpize;
+use PHPUnit\Framework\TestCase;
+
+class ArrayTest extends TestCase
+{
+    public function caseProvider()
+    {
+        return array(
+            array(
+                1,
+                'var a = []; return a.push(4);',
+            ),
+            array(
+                2,
+                'var a = []; a.push(4); return a.push(4);',
+            ),
+            array(
+                array(4),
+                'var a = []; a.push(4); return a;',
+            ),
+        );
+    }
+
+    /**
+     * @group array
+     * @dataProvider caseProvider
+     */
+    public function testArrayResult($expected, $code)
+    {
+        $jsPhpize = new JsPhpize(array(
+            'helpers' => array(
+                'dot' => 'dotWithArrayPrototype',
+            ),
+        ));
+        $actual = $jsPhpize->render($code);
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/badSyntaxes.php
+++ b/tests/badSyntaxes.php
@@ -103,7 +103,7 @@ class BadSyntaxesTest extends TestCase
      */
     public function testBadFunctionCall()
     {
-        new FunctionCall(new Instruction(), array(), array());
+        new FunctionCall(new Instruction(), [], []);
     }
 
     /**

--- a/tests/compile.php
+++ b/tests/compile.php
@@ -43,7 +43,7 @@ class CompileTest extends TestCase
         ));
         $result = $jsPhpize->compileCode('4 + 5');
 
-        $expected = str_replace("\r", '', trim("call_user_func(\$GLOBALS['__jpv_plus'], 4, 5);"));
+        $expected = str_replace("\r", '', trim("\$GLOBALS['__jpv_plus'](4, 5);"));
         $actual = str_replace("\r", '', trim($result));
 
         $this->assertSame($expected, $actual);

--- a/tests/compile.php
+++ b/tests/compile.php
@@ -7,12 +7,12 @@ class CompileTest extends TestCase
 {
     public function caseProvider()
     {
-        $cases = array();
+        $cases = [];
 
         $examples = __DIR__ . '/../examples';
         foreach (scandir($examples) as $file) {
             if (substr($file, -4) === '.php') {
-                $cases[] = array($file, substr($file, 0, -4) . '.js');
+                $cases[] = [$file, substr($file, 0, -4) . '.js'];
             }
         }
 
@@ -38,9 +38,9 @@ class CompileTest extends TestCase
 
     public function testCompileWithoutDependencies()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'catchDependencies' => true,
-        ));
+        ]);
         $result = $jsPhpize->compileCode('4 + 5');
 
         $expected = str_replace("\r", '', trim("\$GLOBALS['__jpv_plus'](4, 5);"));
@@ -51,9 +51,9 @@ class CompileTest extends TestCase
 
     public function testDependenciesGrouping()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'catchDependencies' => true,
-        ));
+        ]);
         $jsPhpize->compileCode("a = 4 + 5;\n b = '9' + '3'");
         $jsPhpize->compileCode('4 + 5');
         $jsPhpize->compileCode('4 + 5 + 9');
@@ -75,9 +75,9 @@ class CompileTest extends TestCase
 
     public function testTruncatedCode()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'catchDependencies' => true,
-        ));
+        ]);
         $result = $jsPhpize->compileCode('} else {');
 
         $expected = str_replace("\r", '', trim('} else {'));
@@ -95,9 +95,9 @@ class CompileTest extends TestCase
 
     public function testCompileDollar()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'ignoreDollarVariable' => true,
-        ));
+        ]);
 
         $actual = trim($jsPhpize->compile('$item'));
 
@@ -125,11 +125,11 @@ class CompileTest extends TestCase
     public function testCompilerException()
     {
         $jsPhpize = new JsPhpize();
-        $jsPhpize->render('a()', array(
+        $jsPhpize->render('a()', [
             'a' => function () {
                 throw new \JsPhpize\Compiler\Exception('custom', 1111111);
             },
-        ));
+        ]);
     }
 
     /**
@@ -149,10 +149,10 @@ class CompileTest extends TestCase
              * comment
              */
             a();
-        ', array(
+        ', [
             'a' => function () {
                 throw new \Exception('custom', 123456);
             },
-        ));
+        ]);
     }
 }

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -27,9 +27,9 @@ class MagicMethodObject
 
 class ArrayAccessObject implements \ArrayAccess
 {
-    protected $data = array(
+    protected $data = [
         'foo' => 'bar',
-    );
+    ];
 
     public function offsetGet($name)
     {
@@ -71,74 +71,74 @@ class DotHelperTest extends TestCase
     {
         $dotHelper = $this->getDotHelper();
 
-        $this->assertSame(42, $dotHelper(array(
+        $this->assertSame(42, $dotHelper([
                 'foo' => 42,
-            ), 'foo'));
-        $this->assertSame('biz', $dotHelper(array(
-                'foo' => array(
+            ], 'foo'));
+        $this->assertSame('biz', $dotHelper([
+                'foo' => [
                     'bar' => 'biz',
-                ),
-            ), 'foo', 'bar'));
-        $this->assertSame(null, $dotHelper(array(
-                'foo' => array(
-                ),
-            ), 'foo', 'bar'));
-        $this->assertSame(null, $dotHelper(array(
-                'foo' => array(
-                ),
-            ), 'biz', 'bar'));
+                ],
+            ], 'foo', 'bar'));
+        $this->assertSame(null, $dotHelper([
+                'foo' => [
+                ],
+            ], 'foo', 'bar'));
+        $this->assertSame(null, $dotHelper([
+                'foo' => [
+                ],
+            ], 'biz', 'bar'));
     }
 
     public function testObjectMember()
     {
         $dotHelper = $this->getDotHelper();
 
-        $this->assertSame(42, $dotHelper((object) array(
+        $this->assertSame(42, $dotHelper((object) [
                 'foo' => 42,
-            ), 'foo'));
-        $this->assertSame('biz', $dotHelper((object) array(
-                'foo' => (object) array(
+            ], 'foo'));
+        $this->assertSame('biz', $dotHelper((object) [
+                'foo' => (object) [
                     'bar' => 'biz',
-                ),
-            ), 'foo', 'bar'));
-        $this->assertSame(null, $dotHelper((object) array(
-                'foo' => (object) array(
-                ),
-            ), 'foo', 'bar'));
-        $this->assertSame(null, $dotHelper((object) array(
-                'foo' => (object) array(
-                ),
-            ), 'biz', 'bar'));
+                ],
+            ], 'foo', 'bar'));
+        $this->assertSame(null, $dotHelper((object) [
+                'foo' => (object) [
+                ],
+            ], 'foo', 'bar'));
+        $this->assertSame(null, $dotHelper((object) [
+                'foo' => (object) [
+                ],
+            ], 'biz', 'bar'));
     }
 
     public function testMixedObjectMemberAndArayValue()
     {
         $dotHelper = $this->getDotHelper();
 
-        $this->assertSame('biz', $dotHelper(array(
-                'foo' => (object) array(
+        $this->assertSame('biz', $dotHelper([
+                'foo' => (object) [
                     'bar' => 'biz',
-                ),
-            ), 'foo', 'bar'));
-        $this->assertSame('biz', $dotHelper((object) array(
-                'foo' => array(
+                ],
+            ], 'foo', 'bar'));
+        $this->assertSame('biz', $dotHelper((object) [
+                'foo' => [
                     'bar' => 'biz',
-                ),
-            ), 'foo', 'bar'));
-        $this->assertSame(42, $dotHelper((object) array(
-                'foo' => array(
-                    'bar' => (object) array(
+                ],
+            ], 'foo', 'bar'));
+        $this->assertSame(42, $dotHelper((object) [
+                'foo' => [
+                    'bar' => (object) [
                         'biz' => 42,
-                    ),
-                ),
-            ), 'foo', 'bar', 'biz'));
-        $this->assertSame(42, $dotHelper(array(
-                'foo' => (object) array(
-                    'bar' => array(
+                    ],
+                ],
+            ], 'foo', 'bar', 'biz'));
+        $this->assertSame(42, $dotHelper([
+                'foo' => (object) [
+                    'bar' => [
                         'biz' => 42,
-                    ),
-                ),
-            ), 'foo', 'bar', 'biz'));
+                    ],
+                ],
+            ], 'foo', 'bar', 'biz'));
     }
 
     public function testMagicMethod()
@@ -150,16 +150,16 @@ class DotHelperTest extends TestCase
         $this->assertSame('biz', call_user_func($dotHelper($object, 'bar')));
         $this->assertSame(null, call_user_func($dotHelper($object, 'biz')));
 
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'returnLastStatement' => true,
-        ));
-        $hello = $jsPhpize->render('__page.seo.title', array(
-            '__page' => array(
-                'seo' => array(
+        ]);
+        $hello = $jsPhpize->render('__page.seo.title', [
+            '__page' => [
+                'seo' => [
                     'title' => 'Hello',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
         $this->assertSame('Hello', $hello);
     }
@@ -182,74 +182,74 @@ class DotHelperTest extends TestCase
         
             return $base;
         }';
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'plus' => $plusHelper,
-            ),
+            ],
             'returnLastStatement' => true,
-        ));
+        ]);
 
         $this->assertEquals(18, $jsPhpize->render('3 + 6'));
 
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'dot' => 'plus',
-            ),
+            ],
             'returnLastStatement' => true,
-        ));
+        ]);
 
-        $this->assertEquals('xb', $jsPhpize->render('a.b', array(
+        $this->assertEquals('xb', $jsPhpize->render('a.b', [
             'a' => 'x',
-        )));
+        ]));
     }
 
     public function testDotObjectHelper()
     {
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'dot' => 'dotObject',
-            ),
+            ],
             'returnLastStatement' => true,
-        ));
+        ]);
 
-        $this->assertEquals('hello', $jsPhpize->render('a.hello', array(
+        $this->assertEquals('hello', $jsPhpize->render('a.hello', [
             'a' => new MagicGetterWithNoIsset(),
-        )));
+        ]));
     }
 
     public function testHelperFile()
     {
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'plus' => __DIR__ . '/Plus.h',
-            ),
+            ],
             'returnLastStatement' => true,
-        ));
+        ]);
 
         $this->assertEquals(6, $jsPhpize->render('13 + 7'));
     }
 
     public function testDotHelperWithArrayPrototype()
     {
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'dot' => 'dotWithArrayPrototype',
-            ),
+            ],
             'returnLastStatement' => true,
-        ));
+        ]);
 
         $this->assertSame(
             '1,3',
             implode(',', $jsPhpize->render('a = [1,2,3]; a.filter(function (i) { return i % 2; })'))
         );
 
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'dot' => 'dotWithArrayPrototype',
-            ),
-        ));
+            ],
+        ]);
 
-        $items = array(1, 2, 3);
+        $items = [1, 2, 3];
         ob_start();
         eval($jsPhpize->compile('items.forEach(function (item) { echo(item); })'));
         $actual = ob_get_contents();
@@ -260,15 +260,15 @@ class DotHelperTest extends TestCase
             $actual
         );
 
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'dot' => 'dotWithArrayPrototype',
-            ),
+            ],
             'allowTruncatedParentheses' => true,
-        ));
+        ]);
 
         ob_start();
-        $items = array(2, 4, 6);
+        $items = [2, 4, 6];
         eval(
             $jsPhpize->compile('items.forEach(function (item) {') .
             ' ?><?php echo ' . $jsPhpize->compile('item') . ' ?><?php ' .

--- a/tests/mainMethods.php
+++ b/tests/mainMethods.php
@@ -23,9 +23,9 @@ EOD;
         $this->assertSame($expected, $actual);
         $this->assertSame('', $jsPhpize->compileDependencies());
 
-        $jsPhpizeCatchDeps = new JsPhpize(array(
+        $jsPhpizeCatchDeps = new JsPhpize([
             'catchDependencies' => true,
-        ));
+        ]);
         $actual = $jsPhpizeCatchDeps->compileFile(__DIR__ . '/../examples/basic.js');
         $expected = <<<'EOD'
 $foo = array( 'bar' => array( "baz" => "hello" ) );
@@ -73,11 +73,11 @@ EOD;
     public function testCompileConcat()
     {
         $jsPhpize = new JsPhpize();
-        $actual = $jsPhpize->render('return "group[" + group.id + "]"', array(
-            'group' => (object) array(
+        $actual = $jsPhpize->render('return "group[" + group.id + "]"', [
+            'group' => (object) [
                 'id' => 4,
-            ),
-        ));
+            ],
+        ]);
         $expected = 'group[4]';
 
         $this->assertSame($expected, $actual);
@@ -89,11 +89,11 @@ EOD;
     public function testConcatenation()
     {
         $jsPhpize = new JsPhpize();
-        $actual = $jsPhpize->render("return 'a' + a.i", array(
-            'a' => array(
+        $actual = $jsPhpize->render("return 'a' + a.i", [
+            'a' => [
                 'i' => 'b',
-            ),
-        ));
+            ],
+        ]);
         $expected = 'ab';
 
         $this->assertSame($expected, $actual);
@@ -101,9 +101,9 @@ EOD;
 
     public function testCompileSource()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'varPrefix' => 'foo',
-        ));
+        ]);
         $actual = $jsPhpize->compileCode('b = 8');
         $expected = '$b = 8;';
         $actual = preg_replace('/\s/', '', $actual);
@@ -128,9 +128,9 @@ EOD;
     public function testRender()
     {
         $jsPhpize = new JsPhpize();
-        $actual = $jsPhpize->render('return b;', array(
+        $actual = $jsPhpize->render('return b;', [
             'b' => 42,
-        ));
+        ]);
         $expected = 42;
         $this->assertSame($expected, $actual);
 
@@ -139,9 +139,9 @@ EOD;
         $expected = null;
         $this->assertSame($expected, $actual);
 
-        $jsPhpize->share('b', array(31));
+        $jsPhpize->share('b', [31]);
         $actual = $jsPhpize->render('return b;');
-        $expected = array(31);
+        $expected = [31];
         $this->assertSame($expected, $actual);
 
         $jsPhpize->resetSharedVariables();

--- a/tests/mainMethods.php
+++ b/tests/mainMethods.php
@@ -10,11 +10,13 @@ class MainMethodsTest extends TestCase
         $jsPhpize = new JsPhpize();
         $actual = $jsPhpize->compileFile(__DIR__ . '/../examples/basic.js');
         $expected = '$GLOBALS[\'__jpv_dot\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Dot.h') . ';';
+        $expected .= '$GLOBALS[\'__jpv_dot_with_ref\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Dot.ref.h') . ';';
         $expected .= '$GLOBALS[\'__jpv_plus\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Plus.h') . ';';
+        $expected .= '$GLOBALS[\'__jpv_plus_with_ref\'] = $GLOBALS[\'__jpv_plus\'];';
         $expected .= <<<'EOD'
 $foo = array( 'bar' => array( "baz" => "hello" ) );
 $biz = 'bar';
-return call_user_func($GLOBALS['__jpv_plus'], call_user_func($GLOBALS['__jpv_dot'], $foo, 'bar', "baz"), ' ', call_user_func($GLOBALS['__jpv_dot'], $foo, $biz, 'baz'), " ", call_user_func($GLOBALS['__jpv_dot'], $foo, 'bar', 'baz'));
+return $GLOBALS['__jpv_plus']($GLOBALS['__jpv_dot_with_ref']($foo, 'bar', "baz"), ' ', $GLOBALS['__jpv_dot_with_ref']($foo, $biz, 'baz'), " ", $GLOBALS['__jpv_dot_with_ref']($foo, 'bar', 'baz'));
 EOD;
         $actual = str_replace(';', ";\n", preg_replace('/\s/', '', $actual));
         $expected = str_replace(';', ";\n", preg_replace('/\s/', '', $expected));
@@ -28,7 +30,7 @@ EOD;
         $expected = <<<'EOD'
 $foo = array( 'bar' => array( "baz" => "hello" ) );
 $biz = 'bar';
-return call_user_func($GLOBALS['__jpv_plus'], call_user_func($GLOBALS['__jpv_dot'], $foo, 'bar', "baz"), ' ', call_user_func($GLOBALS['__jpv_dot'], $foo, $biz, 'baz'), " ", call_user_func($GLOBALS['__jpv_dot'], $foo, 'bar', 'baz'));
+return $GLOBALS['__jpv_plus']($GLOBALS['__jpv_dot_with_ref']($foo, 'bar', "baz"), ' ', $GLOBALS['__jpv_dot_with_ref']($foo, $biz, 'baz'), " ", $GLOBALS['__jpv_dot_with_ref']($foo, 'bar', 'baz'));
 EOD;
         $actual = preg_replace('/\s/', '', $actual);
         $expected = preg_replace('/\s/', '', $expected);
@@ -37,7 +39,9 @@ EOD;
         $actual = $jsPhpizeCatchDeps->compileDependencies();
         $jsPhpizeCatchDeps->flushDependencies();
         $expected = '$GLOBALS[\'__jpv_dot\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Dot.h') . ';';
+        $expected .= '$GLOBALS[\'__jpv_dot_with_ref\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Dot.ref.h') . ';';
         $expected .= '$GLOBALS[\'__jpv_plus\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Plus.h') . ';';
+        $expected .= '$GLOBALS[\'__jpv_plus_with_ref\'] = $GLOBALS[\'__jpv_plus\'];';
 
         $actual = preg_replace('/\s/', '', $actual);
         $expected = preg_replace('/\s/', '', $expected);
@@ -46,6 +50,7 @@ EOD;
         $jsPhpizeCatchDeps->compileFile(__DIR__ . '/../examples/calcul.js');
         $actual = $jsPhpizeCatchDeps->compileDependencies();
         $expected = '$GLOBALS[\'__jpv_plus\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Plus.h') . ';';
+        $expected .= '$GLOBALS[\'__jpv_plus_with_ref\'] = $GLOBALS[\'__jpv_plus\'];';
         $actual = preg_replace('/\s/', '', $actual);
         $expected = preg_replace('/\s/', '', $expected);
         $this->assertSame($expected, $actual);
@@ -110,9 +115,10 @@ EOD;
         $actual = $jsPhpize->compileCode('calcul.js');
         chdir($dir);
         $expected = '$GLOBALS[\'foodot\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Dot.h') . ';';
+        $expected .= '$GLOBALS[\'foodot_with_ref\'] = ' . file_get_contents(__DIR__ . '/../src/JsPhpize/Compiler/Helpers/Dot.ref.h') . ';';
 
         $expected .= <<<'EOD'
-call_user_func($GLOBALS['foodot'], $calcul, 'js');
+$GLOBALS['foodot_with_ref']($calcul, 'js');
 EOD;
         $actual = preg_replace('/\s/', '', $actual);
         $expected = preg_replace('/\s/', '', $expected);

--- a/tests/options.php
+++ b/tests/options.php
@@ -11,9 +11,9 @@ class OptionsTest extends TestCase
      */
     public function testDisallow()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'disallow' => 'foo bar',
-        ));
+        ]);
         $this->assertSame(6, $jsPhpize->render('
             var a = 3;
             for (i = 0; i < 3; i++) {
@@ -22,9 +22,9 @@ class OptionsTest extends TestCase
             return a;
         '));
 
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'disallow' => 'foo comment bar',
-        ));
+        ]);
         $code = null;
 
         try {
@@ -48,9 +48,9 @@ class OptionsTest extends TestCase
      */
     public function testConstPrefixRestriction()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'constPrefix' => 'FOO',
-        ));
+        ]);
         $jsPhpize->render('
             var a = FOOBAR;
         ');
@@ -62,9 +62,9 @@ class OptionsTest extends TestCase
      */
     public function testVarPrefixRestriction()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'varPrefix' => 'test',
-        ));
+        ]);
         $jsPhpize->render('
             var a = test_zz;
         ');
@@ -75,18 +75,18 @@ class OptionsTest extends TestCase
      */
     public function testReturnLastStatement()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'returnLastStatement' => true,
-        ));
+        ]);
         $eleven = $jsPhpize->render('
             var a = 8;
             a + 3;
         ');
         $this->assertSame(11, $eleven);
 
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'returnLastStatement' => false,
-        ));
+        ]);
         $defaultReturn = $jsPhpize->render('
             var a = 8;
             a + 3;
@@ -113,9 +113,9 @@ class OptionsTest extends TestCase
     public function testPatterns()
     {
         include_once __DIR__ . '/TestToken.php';
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'tokenClass' => 'TestToken',
-        ));
+        ]);
         $jsPhpize->addPattern(new Pattern(0, 'operator', '@'));
         $code = $jsPhpize->compile('1 @ 8');
         $this->assertSame('1 @ 8;', trim($code));
@@ -129,11 +129,11 @@ class OptionsTest extends TestCase
     public function testPatternsException()
     {
         include_once __DIR__ . '/TestToken.php';
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'tokenClass' => 'TestToken',
-        ));
+        ]);
         $jsPhpize->removePatterns(function (Pattern $pattern) {
-            return !in_array($pattern->type, array('number', 'operator'));
+            return !in_array($pattern->type, ['number', 'operator']);
         });
         $jsPhpize->compile('1 + 1');
     }
@@ -142,9 +142,9 @@ class OptionsTest extends TestCase
     {
         $jsPhpize = new JsPhpize();
         self::assertSame('FOO', trim($jsPhpize->compile('FOO'), " \n;"));
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'disableConstants' => true,
-        ));
+        ]);
         self::assertSame('$FOO', trim($jsPhpize->compile('FOO'), " \n;"));
     }
 }

--- a/tests/render.php
+++ b/tests/render.php
@@ -7,12 +7,12 @@ class RenderTest extends TestCase
 {
     public function caseProvider()
     {
-        $cases = array();
+        $cases = [];
 
         $examples = __DIR__ . '/../examples';
         foreach (scandir($examples) as $file) {
             if (substr($file, -7) === '.return') {
-                $cases[] = array($file, substr($file, 0, -7) . '.js');
+                $cases[] = [$file, substr($file, 0, -7) . '.js'];
             }
         }
 
@@ -26,11 +26,11 @@ class RenderTest extends TestCase
     public function testJsPhpizeGeneration($returnFile, $jsFile)
     {
         $examples = __DIR__ . '/../examples';
-        $jsPhpize = new JsPhpize(array(
-            'helpers' => array(
+        $jsPhpize = new JsPhpize([
+            'helpers' => [
                 'dot' => 'dotWithArrayPrototype',
-            ),
-        ));
+            ],
+        ]);
         $expected = file_get_contents($examples . '/' . $returnFile);
 
         try {

--- a/tests/unexpectedTokens.php
+++ b/tests/unexpectedTokens.php
@@ -91,9 +91,9 @@ class UnexpectedTokensTest extends TestCase
      */
     public function testUnexpectedInBlock()
     {
-        $jsPhpize = new JsPhpize(array(
+        $jsPhpize = new JsPhpize([
             'strict' => true,
-        ));
+        ]);
         $jsPhpize->render('a = true; )');
     }
 }


### PR DESCRIPTION
- Drop PHP 5.3 and 5.4
- Allow references (array.push, array.unshift, etc.)
- Add an abstract class DynamicValue for Variable and FunctionCall